### PR TITLE
Reworking death message handling, Adding new death messages

### DIFF
--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/configuration/PluginMessages.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/configuration/PluginMessages.java
@@ -162,8 +162,13 @@ public class PluginMessages {
         ARENA_NOT_HIGHER("arena.not_higher", "&cYou can not go higher."),
         ARENA_KICK_INACTIVITY("arena.kick_inactivity", "&cYou were inactive on MissileWars."),
 
-        DIED_NORMAL("died.normal", "&7%player% &7died."),
-        DIED_EXPLOSION("died.explosion", "&7%player% &7was blown up."),
+        DIED_EXPLOSION_TNT("died.explosion_tnt", "%player_displayname% &7was blown up by TNT."),
+        DIED_EXPLOSION_MINECART("died.explosion_minecart", "%player_displayname% &7was blown up by a TNT minecart."),
+        DIED_PROJECTILE_FIREBALL("died.projectile_fireball", "%player_displayname% &7was hit by a fireball from %killer_displayname%&7."),
+        DIED_PROJECTILE_ARROW("died.projectile_arrow", "%player_displayname% &7was shot by %killer_displayname% &7with an arrow."),
+        DIED_ENTITY_ATTACK("died.entity_attack", "%player_displayname% &7was killed in PVP by %killer_displayname%&7."),
+        DIED_FALL("died.fall", "%player_displayname% &7has fallen to his death."),
+        DIED_DEFAULT("died.default", "%player_displayname% &7died."),
 
         FALL_PROTECTION_START("fall_protection.start", "&cFall protection inactive in %seconds% seconds."),
         FALL_PROTECTION_END("fall_protection.end", "&cFall protection inactive."),

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/DeathMessageHandler.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/DeathMessageHandler.java
@@ -1,0 +1,111 @@
+package de.butzlabben.missilewars.game;
+
+import de.butzlabben.missilewars.Logger;
+import de.butzlabben.missilewars.configuration.PluginMessages;
+import org.bukkit.entity.*;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+
+public class DeathMessageHandler {
+    
+    private final Game game;
+    
+    public DeathMessageHandler(Game game) {
+        this.game = game;
+    }
+    
+    public void sendDeathMessage(Player player) {
+        
+        if (player.getLastDamageCause() == null) return;
+        
+        String deathBroadcast = PluginMessages.getMessage(true, PluginMessages.MessageEnum.DIED_DEFAULT)
+                .replace("%player%", player.getName())
+                .replace("%player_displayname%", player.getDisplayName());
+        
+        EntityDamageEvent.DamageCause damageCause = player.getLastDamageCause().getCause();
+        
+        if ((damageCause == EntityDamageEvent.DamageCause.BLOCK_EXPLOSION) || (damageCause == EntityDamageEvent.DamageCause.ENTITY_EXPLOSION)) {
+            
+            if (player.getLastDamageCause() instanceof EntityDamageByEntityEvent damageByEntity) {
+                Entity damager = damageByEntity.getDamager();
+                
+                if (damager.getType() == EntityType.TNT) {
+                    deathBroadcast = PluginMessages.getMessage(true, PluginMessages.MessageEnum.DIED_EXPLOSION_TNT)
+                            .replace("%player%", player.getName())
+                            .replace("%player_displayname%", player.getDisplayName());
+
+                } else if (damager.getType() == EntityType.TNT_MINECART) {
+                    deathBroadcast = PluginMessages.getMessage(true, PluginMessages.MessageEnum.DIED_EXPLOSION_MINECART)
+                            .replace("%player%", player.getName())
+                            .replace("%player_displayname%", player.getDisplayName());
+                    
+                } else if (damager instanceof Fireball fireball) {
+                    if (fireball.getShooter() instanceof Player killer) {
+                        deathBroadcast = PluginMessages.getMessage(true, PluginMessages.MessageEnum.DIED_PROJECTILE_FIREBALL)
+                                .replace("%player%", player.getName())
+                                .replace("%player_displayname%", player.getDisplayName())
+                                .replace("%killer%", killer.getName())
+                                .replace("%killer_displayname%", killer.getDisplayName());
+                    }
+                }
+            }
+        
+        
+        } else if (damageCause == EntityDamageEvent.DamageCause.PROJECTILE) {
+            
+            if (player.getLastDamageCause() instanceof EntityDamageByEntityEvent damageByEntity) {
+                Entity damager = damageByEntity.getDamager();
+                
+                if (damager instanceof Arrow arrow) {
+                    if (arrow.getShooter() instanceof Player killer) {
+                        deathBroadcast = PluginMessages.getMessage(true, PluginMessages.MessageEnum.DIED_PROJECTILE_ARROW)
+                                .replace("%player%", player.getName())
+                                .replace("%player_displayname%", player.getDisplayName())
+                                .replace("%killer%", killer.getName())
+                                .replace("%killer_displayname%", killer.getDisplayName());
+                    }
+                    
+                } else if (damager instanceof Fireball fireball) {
+                    if (fireball.getShooter() instanceof Player killer) {
+                        deathBroadcast = PluginMessages.getMessage(true, PluginMessages.MessageEnum.DIED_PROJECTILE_FIREBALL)
+                                .replace("%player%", player.getName())
+                                .replace("%player_displayname%", player.getDisplayName())
+                                .replace("%killer%", killer.getName())
+                                .replace("%killer_displayname%", killer.getDisplayName());
+                    }
+                }
+            }
+            
+            
+        } else if ((damageCause == EntityDamageEvent.DamageCause.ENTITY_ATTACK) || (damageCause == EntityDamageEvent.DamageCause.ENTITY_SWEEP_ATTACK)) {
+            
+            if (player.getLastDamageCause() instanceof EntityDamageByEntityEvent damageByEntity) {
+                Entity damager = damageByEntity.getDamager();
+                
+                if (damager instanceof LivingEntity entity) {
+                    if (entity instanceof Player killer) {
+                        deathBroadcast = PluginMessages.getMessage(true, PluginMessages.MessageEnum.DIED_ENTITY_ATTACK)
+                                .replace("%player%", player.getName())
+                                .replace("%player_displayname%", player.getDisplayName())
+                                .replace("%killer%", killer.getName())
+                                .replace("%killer_displayname%", killer.getDisplayName());
+                    }
+                }
+            }
+            
+            
+        } else if (damageCause == EntityDamageEvent.DamageCause.FALL) {
+            deathBroadcast = PluginMessages.getMessage(true, PluginMessages.MessageEnum.DIED_FALL)
+                    .replace("%player%", player.getName())
+                    .replace("%player_displayname%", player.getDisplayName());
+            
+            
+        }
+
+        Logger.DEBUG.log("Death by " + player.getName() + ": " + damageCause.name() + " (" + player.getLastDamageCause().getClass().getSimpleName() + ")");
+        
+        game.broadcast(deathBroadcast);
+    
+    }
+    
+}

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/Game.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/Game.java
@@ -95,6 +95,7 @@ public class Game {
     private GameJoinManager gameJoinManager;
     private GameLeaveManager gameLeaveManager;
     private GameBoundListener listener;
+    private DeathMessageHandler deathMsgHandler;
     private EquipmentManager equipmentManager;
     private TaskManager taskManager;
     private int remainingGameDuration;
@@ -240,6 +241,8 @@ public class Game {
         taskManager.setTimer(new GameTimer(this, arenaConfig.getGameDuration() * 60));
         taskManager.runTimer(5, 20);
         state = GameState.INGAME;
+        
+        deathMsgHandler = new DeathMessageHandler(this);
 
         timestart = System.currentTimeMillis();
 

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/game/GameListener.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/game/GameListener.java
@@ -210,30 +210,17 @@ public class GameListener extends GameBoundListener {
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onDeath(PlayerDeathEvent event) {
-        if (!isInGameWorld(event.getEntity().getLocation())) return;
+        if (!isInGameWorld(event.getPlayer().getLocation())) return;
 
-        Player player = event.getEntity();
+        Player player = event.getPlayer();
         MWPlayer mwPlayer = getGame().getPlayer(player);
         Team team = mwPlayer.getTeam();
-
-        // check the death cause for choice the death message
+        
         if (team.getTeamType() == TeamType.PLAYER) {
-
-            if (player.getLastDamageCause() == null) return;
-
-            String deathBroadcast;
-            EntityDamageEvent.DamageCause damageCause = player.getLastDamageCause().getCause();
-
-            if (damageCause == EntityDamageEvent.DamageCause.BLOCK_EXPLOSION || damageCause == EntityDamageEvent.DamageCause.ENTITY_EXPLOSION) {
-                deathBroadcast = PluginMessages.getMessage(true, PluginMessages.MessageEnum.DIED_EXPLOSION).replace("%player%", player.getDisplayName());
-            } else {
-                deathBroadcast = PluginMessages.getMessage(true, PluginMessages.MessageEnum.DIED_NORMAL).replace("%player%", player.getDisplayName());
-            }
-
-            getGame().broadcast(deathBroadcast);
+            getGame().getDeathMsgHandler().sendDeathMessage(player);
+            event.setDeathMessage(null);
         }
-
-        event.setDeathMessage(null);
+        
         player.setLevel(0);
         
         if (getGame().getArenaConfig().isAutoRespawn()) getGame().autoRespawnPlayer(mwPlayer);


### PR DESCRIPTION
# Overview
- Adding `DeathMessageHandler` class
- Adding and improving death messages in `messages.yml`
  - `died.normal` renamed to `died.default`
  - `died.explosion` was split into `died.explosion_tnt` and `died.explosion_minecart`

# New Death Message Settings

All messages support the normal `%player%` placeholder (player name without team color) and the `%player_displayname%` placeholder (player name with team color). Same for the killer, if one exists (`%killer%`, `%killer_displayname%`).

**New `messages.yml` config section:**

```yml
died:
  explosion_tnt: '%player_displayname% &7was blown up by TNT.'
  explosion_minecart: '%player_displayname% &7was blown up by a TNT minecart.'
  projectile_fireball: '%player_displayname% &7was hit by a fireball from %killer_displayname%&7.'
  projectile_arrow: '%player_displayname% &7was shot by %killer_displayname% &7with
    an arrow.'
  entity_attack: '%player_displayname% &7was killed in PVP by %killer_displayname%&7.'
  fall: '%player_displayname% &7has fallen to his death.'
  default: '%player_displayname% &7died.'
```